### PR TITLE
chore(deps): use mandrel-for-jdk21-rhel8 and use buildah with compute resources

### DIFF
--- a/.tekton/osv-ingester-pull-request.yaml
+++ b/.tekton/osv-ingester-pull-request.yaml
@@ -29,6 +29,15 @@ spec:
       value: src/main/docker/Dockerfile.multi-stage
     - name: path-context
       value: .
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs:
+        - name: build
+          computeResources:
+            requests:
+              memory: 8Gi
+            limits:
+              memory: 8Gi
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -238,7 +247,7 @@ spec:
             - name: name
               value: buildah
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:815f96d14e7aababdaf42cd476b33df2bd7632782ee48a50dba869d1e2976ac8
+              value: quay.io/konflux-ci/tekton-catalog/task-buildah@sha256:d588db7bfd8cd0b951de7f7a3929ba5870e8ab1e35bd45056d03fd9c2972fcf1
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/osv-ingester-push.yaml
+++ b/.tekton/osv-ingester-push.yaml
@@ -27,6 +27,15 @@ spec:
     value: src/main/docker/Dockerfile.multi-stage
   - name: path-context
     value: .
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs:
+        - name: build
+          computeResources:
+            requests:
+              memory: 8Gi
+            limits:
+              memory: 8Gi
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -237,9 +246,9 @@ spec:
       taskRef:
         params:
         - name: name
-          value: buildah-8gb
+          value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-8gb:0.2@sha256:976128cdd109b87bb758e2b77dff5a1cb261fdeb9d280b937b1c67860d829786
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah@sha256:d588db7bfd8cd0b951de7f7a3929ba5870e8ab1e35bd45056d03fd9c2972fcf1
         - name: kind
           value: task
         resolver: bundles

--- a/src/main/docker/Dockerfile.multi-stage
+++ b/src/main/docker/Dockerfile.multi-stage
@@ -1,5 +1,5 @@
 ## Stage 1 : build with maven builder image with native capabilities
-FROM registry.redhat.io/quarkus/mandrel-23-rhel8:23.0 AS build
+FROM registry.redhat.io/quarkus/mandrel-for-jdk-21-rhel8:23.1 AS build
 
 COPY --chown=quarkus:quarkus mvnw /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn


### PR DESCRIPTION
Image `mandrel-23-rhel8:23.0` is deprecated
And the buildah-8g task is deprecated as well